### PR TITLE
[Dockerfile] Use apk's --no-cache option instead of updating and removing cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine:3.4
 
 ENV DOCTL_VERSION=1.5.0
 
-RUN apk add --update curl && \
-    rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 


### PR DESCRIPTION
This is a minor change for something that I noticed while checking out the Dockerfile for this project – Alpine 3.3 and above support the `--no-cache` option in `apk` that will update the package index at runtime and not cache the results locally. This means that `--update` is not required and the additional cache removal step can be skipped.

[Alpine's documentation](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache) explains further.